### PR TITLE
Fix compiling with -DCOMPILE_MULTIMON_STUBS

### DIFF
--- a/mingw-w64-headers/include/multimon.h
+++ b/mingw-w64-headers/include/multimon.h
@@ -127,7 +127,7 @@ extern "C" {
   WINBOOL IsPlatformNT() {
     OSVERSIONINFOA oi = { 0 };
 
-    oi.dwOSVersionInfoSize = sizeof (osvi);
+    oi.dwOSVersionInfoSize = sizeof (oi);
     GetVersionExA ((OSVERSIONINFOA *) &oi);
     return (oi.dwPlatformId == VER_PLATFORM_WIN32_NT);
   }
@@ -241,7 +241,7 @@ extern "C" {
       f = g_pfnGetMonitorInfo (hmon, pmi);
 #ifdef UNICODE
       if (f && !g_fMultimonPlatformNT && pmi->cbSize >= sizeof (MONITORINFOEX))
-	MultiByteToWideChar (CP_ACP, 0, (LPSTR) c.ex->szDevice, -1, c.ex->szDevice, (sizeof (c.ex->szDevice) / 2));
+	MultiByteToWideChar (CP_ACP, 0, (LPSTR) c.ex.szDevice, -1, c.ex.szDevice, (sizeof (c.ex.szDevice) / 2));
 #endif
       return f;
     }
@@ -255,9 +255,9 @@ extern "C" {
       pmi->dwFlags = MONITORINFOF_PRIMARY;
       if (pmi->cbSize >= sizeof (MONITORINFOEX)) {
 #ifdef UNICODE
-	MultiByteToWideChar (CP_ACP, 0, "DISPLAY", -1, c.ex->szDevice, (sizeof (c.ex->szDevice) / 2));
+	MultiByteToWideChar (CP_ACP, 0, "DISPLAY", -1, c.ex.szDevice, (sizeof (c.ex.szDevice) / 2));
 #else
-	lstrcpyn (c.ex->szDevice, "DISPLAY", sizeof (c.ex->szDevice));
+	lstrcpyn (c.ex.szDevice, "DISPLAY", sizeof (c.ex.szDevice));
 #endif
       }
 


### PR DESCRIPTION
Otherwise the compiler is unhappy. Apparently bugs introduced in commits
4c6a85e6fd024d2b76324a1ed29de44e84e38b51 and
c0f26d698843542965722d8ddc6f1b8f773c8aad

With this fix it compiles and seems to work fine on multi-monitor setup.